### PR TITLE
If the text haven't been committed it should _probably_ be discarded.

### DIFF
--- a/gooey/internal/input.lua
+++ b/gooey/internal/input.lua
@@ -125,6 +125,7 @@ function M.input(node_id, keyboard_type, action_id, action, config, refresh_fn)
 			gui.show_keyboard(keyboard_type, true)
 		elseif input.selected and action.pressed and action_id == actions.TOUCH and not input.over then
 			input.selected = false
+			input.marked_text = ""
 			gui.hide_keyboard()
 		end
 


### PR DESCRIPTION
This is only applicable on device. This needs to be discussed before it can be merged.

### Current behaviour
1. Input text
2. Click outside of the node
    * The text you put in stays
    * gui.get_text returns the text
3. Click the node again
    * The text input gets cleared

I personally think that one of these two options is more intuitive
### Expected behavior 1 (this PR)
1. Input text
2. Click outside of the node
    * The text input gets cleared

### Expected behavior 2 (don't "mark text")
1. Input text
2. Click outside of the node
    * The text you put in stays
    * gui.get_text returns the text
3. Click the node again
     * The text you put in stays

___

I think it could be beneficial to use behavior 1 and have a option `INPUT.set_auto_commit_text(input, commit)` so the user can skip the "need to press enter" (which I personally would always use)