### PR TITLE
Keep input text in the node's bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,7 @@ The configuration table accepts the following values:
 * ```empty_text``` (string) - Text to show if the text field is empty
 * ```allowed_characters``` (string) - Lua pattern to filter allowed characters (eg "[%a%d]" for alpha numeric)
 * ```use_marked_text``` (bool) - Flag to disable the usage of marked (non-committed) text, defaults to true
+* ```keep_in_bounds``` (bool) - Flag to disable text being automatically kept inside the node's bounds, defaults to true
 
 **RETURN**
 * ```input``` (table) - State data for the input field based on current and previous input actions

--- a/gooey/internal/input.lua
+++ b/gooey/internal/input.lua
@@ -148,6 +148,12 @@ function M.input(node_id, keyboard_type, action_id, action, config, refresh_fn)
 				-- ignore arrow keys
 				if not string.match(hex, "EF9C8[0-3]") then
 					if not config or not config.allowed_characters or action.text:match(config.allowed_characters) then
+						if not (config and config.keep_in_bounds == false) then
+							if get_text_width(node, input.text .. action.text) > gui.get_size(node).x * gui.get_scale(node).x then
+								if refresh_fn then refresh_fn(input) end
+								return input
+							end
+						end
 						input.text = input.text .. action.text
 						if config and config.max_length then
 							input.text = utf8.sub(input.text, 1, config.max_length)


### PR DESCRIPTION
Prevent the text in an input node from exceeding the node's width, unless `config.keep_in_bounds` is set to `false`.