### PR TITLE
Added node_id to component properties.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Perform input and state handling for a button
 The state table contains the following fields:
 
 * ```node``` (node) - The node itself
+* ```node_id``` (node_id) - Hashed id of the node
 * ```enabled``` (boolean) - true if the node is enabled
 * ```consumed``` (boolean) - true if the input was consumed
 * ```clicked``` (boolean) - true if the input is considered a click (ie pressed and released cycle)
@@ -139,6 +140,7 @@ Perform input and state handling for a checkbox
 The state table contains the following fields:
 
 * ```node``` (node) - The node itself
+* ```node_id``` (node_id) - Hashed id of the node
 * ```enabled``` (boolean) - true if the node is enabled
 * ```consumed``` (boolean) - true if the input was consumed
 * ```clicked``` (boolean) - true if the input is considered a click (ie pressed and released cycle)
@@ -209,6 +211,7 @@ Perform input and state handling for a radio button
 The state table contains the following fields:
 
 * ```node``` (node) - The node itself
+* ```node_id``` (node_id) - Hashed id of the node
 * ```enabled``` (boolean) - true if the node is enabled
 * ```consumed``` (boolean) - true if the input was consumed
 * ```clicked``` (boolean) - true if the input is considered a click (ie pressed and released cycle)
@@ -510,6 +513,7 @@ The configuration table accepts the following values:
 The state table contains the following fields:
 
 * ```node``` (node) - The node itself
+* ```node_id``` (node_id) - Hashed id of the node
 * ```enabled``` (boolean) - true if the node is enabled
 * ```consumed``` (boolean) - true if the input was consumed
 * ```over``` (boolean) - true if user action is inside the node

--- a/gooey/internal/button.lua
+++ b/gooey/internal/button.lua
@@ -24,6 +24,7 @@ function M.button(node_id, action_id, action, fn, refresh_fn)
 	local button = core.instance(node_id, buttons, BUTTON)
 	button.enabled = core.is_enabled(node)
 	button.node = node
+	button.node_id = node_id
 	button.refresh_fn = refresh_fn
 
 	core.clickable(button, action_id, action)

--- a/gooey/internal/checkbox.lua
+++ b/gooey/internal/checkbox.lua
@@ -33,6 +33,7 @@ function M.checkbox(node_id, action_id, action, fn, refresh_fn)
 	local checkbox = core.instance(node_id, checkboxes, CHECKBOX)
 	checkbox.enabled = core.is_enabled(node)
 	checkbox.node = node
+	checkbox.node_id = node_id
 	checkbox.refresh_fn = refresh_fn
 
 	core.clickable(checkbox, action_id, action)

--- a/gooey/internal/input.lua
+++ b/gooey/internal/input.lua
@@ -117,6 +117,7 @@ function M.input(node_id, keyboard_type, action_id, action, config, refresh_fn)
 	local input = core.instance(node_id, inputfields, INPUT)
 	input.enabled = core.is_enabled(node)
 	input.node = node
+	input.node_id = node_id
 	input.refresh_fn = refresh_fn
 	
 	local use_marked_text = (config and config.use_marked_text == nil) and true or (config and config.use_marked_text)

--- a/gooey/internal/radio.lua
+++ b/gooey/internal/radio.lua
@@ -40,6 +40,7 @@ function M.button(node_id, group_id, action_id, action, fn, refresh_fn)
 	local radio = core.instance(node_id, radiobuttons, RADIOBUTTON)
 	radio.enabled = core.is_enabled(node)
 	radio.node = node
+	radio.node_id = node_id
 	radio.group = group_id and core.to_key(group_id)
 	radio.refresh_fn = refresh_fn
 

--- a/gooey/internal/scrollbar.lua
+++ b/gooey/internal/scrollbar.lua
@@ -54,6 +54,7 @@ function M.vertical(handle_id, bounds_id, action_id, action, fn, refresh_fn)
 
 	scrollbar.enabled = core.is_enabled(handle)
 	scrollbar.node = handle
+	scrollbar.node_id = node_id
 	scrollbar.bounds = bounds
 	scrollbar.bounds_size = bounds_size
 	scrollbar.handle_size = handle_size


### PR DESCRIPTION
It would be useful to get the node_id in the widget callback functions. This way, data from tables can be easily retrieved when the table's key is the node_id.

Example:
```
local apple_hash = hash("apple_hash")
local banana_hash = hash("banana_hash")

local table = { [apple_hash] = { color: "red" }, [banana_hash] = { color: "yellow" } }

local function button_callback(button)
    print("My color is: " .. table[button.node_id])
end
```