### PR TITLE
Fixed input `get_text_width`

### DIFF
--- a/gooey/internal/input.lua
+++ b/gooey/internal/input.lua
@@ -5,30 +5,13 @@ local utf8 = require "gooey.internal.utf8"
 local M = {}
 
 local inputfields = {}
-local space_width = {}
 
--- calculate space width with font
-local function get_space_width(font)
-	if not space_width[font] then
-		local no_space = gui.get_text_metrics(font, "1", 0, false, 0, 0).width
-		local with_space = gui.get_text_metrics(font, " 1", 0, false, 0, 0).width
-		space_width[font] = with_space - no_space
-	end 
-	return space_width[font]
-end
 
--- calculate text width with font with respect to trailing space (issue DEF-1761)
+-- calculate text width with font
 local function get_text_width(node, text)
 	local font = gui.get_font(node)
 	local scale = gui.get_scale(node)
 	local result = gui.get_text_metrics(font, text, 0, false, 0, 0).width
-	for i=#text, 1, -1 do
-		local c = string.sub(text, i, i)
-		if c ~= ' ' then
-			break
-		end
-		result = result + get_space_width(font)
-	end
 	result = result * scale.x
 	return result
 end


### PR DESCRIPTION
![before](https://user-images.githubusercontent.com/99901732/194728396-62963892-00c9-42f8-953d-8352e71379c9.gif)
(Before the fix) More characters are removed from the ui text content than actually needs to be for every trailing space added.

![after](https://user-images.githubusercontent.com/99901732/194728395-1c12acb4-3706-442d-88e3-38aeafd3ee5b.gif)
(After the fix) The characters are properly removed when adding trailing spaces.

Fixes #75 